### PR TITLE
Update ui

### DIFF
--- a/BitAvalanche/Core/Logger.cs
+++ b/BitAvalanche/Core/Logger.cs
@@ -94,7 +94,7 @@ public sealed class Logger
             if (!first)
                 msg.Append(", ");
             first = false;
-            msg.Append(obj.ToString());
+            msg.Append(obj?.ToString() ?? "null");
         }
         Logger.Debug(msg.ToString(), member, ln);
     }

--- a/BitAvalanche/Views/TorrentLibrary.axaml
+++ b/BitAvalanche/Views/TorrentLibrary.axaml
@@ -8,7 +8,8 @@
         x:Class="BitAvalanche.Views.TorrentLibrary"
         x:DataType="vm:TorrentLibraryViewModel"
         Icon="/Assets/avalonia-logo.ico"
-        Title="BitAvalanche">
+        Title="BitAvalanche"
+        ClientSize="800,450">
 
   <Design.DataContext>
     <!-- This only sets the DataContext for the previewer in an IDE,
@@ -33,15 +34,18 @@
     </Grid>
 
     <Expander DockPanel.Dock="Bottom" ExpandDirection="Up" HorizontalAlignment="Stretch">
+      <Expander.Header>
+        Additional Info
+      </Expander.Header>
       <views:TorrentLongInfoView DataContext="{Binding #Torrents.SelectedItem}" />
     </Expander>
 
-    <Grid DockPanel.Dock="Top" ColumnDefinitions="4*,3*,1*,1*,1*">
-      <TextBlock Grid.Column="0" Text="Name" />
-      <TextBlock Grid.Column="1" Text="Progress" />
-      <TextBlock Grid.Column="2" Text="Peers" />
-      <TextBlock Grid.Column="3" Text="Downloaded" />
-      <TextBlock Grid.Column="4" Text="Uploaded" />
+    <Grid ColumnDefinitions="3*,3*,*,*,*" Name="Header" DockPanel.Dock="Top" Margin="12 0">
+      <TextBlock Grid.Column="0" HorizontalAlignment="Stretch" Text="Name" />
+      <TextBlock Grid.Column="1" HorizontalAlignment="Stretch" Text="Progress" />
+      <TextBlock Grid.Column="2" HorizontalAlignment="Stretch" TextAlignment="End" Text="Peers" />
+      <TextBlock Grid.Column="3" HorizontalAlignment="Stretch" TextAlignment="End" Text="Downloaded" />
+      <TextBlock Grid.Column="4" HorizontalAlignment="Stretch" TextAlignment="End" Text="Uploaded" />
     </Grid>
 
     <ListBox DockPanel.Dock="Top"

--- a/BitAvalanche/Views/TorrentShortInfoView.axaml
+++ b/BitAvalanche/Views/TorrentShortInfoView.axaml
@@ -20,25 +20,21 @@
     <Style Selector="Grid > Layoutable">
       <Setter Property="VerticalAlignment" Value="Stretch" />
     </Style>
-    <Style Selector="Grid > TemplatedControl:nth-child(even)">
-      <Setter Property="Background" Value="Gainsboro" />
-    </Style>
-    <Style Selector="Grid > TextBlock:nth-child(even)">
-      <Setter Property="Background" Value="Gainsboro" />
-    </Style>
   </UserControl.Styles>
 
-  <Grid ColumnDefinitions="4*,3*,1*,1*,1*" VerticalAlignment="Stretch">
-    <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" Grid.Column="0"/>
+  <Grid ColumnDefinitions="3*,3*,1*,1*,1*" VerticalAlignment="Stretch">
+    <TextBlock Text="{Binding Name}" TextAlignment="Start" TextTrimming="CharacterEllipsis" HorizontalAlignment="Stretch" Grid.Column="0"/>
     <ProgressBar Minimum="0"
                  Maximum="1"
+                 MinWidth="1"
                  Value="{Binding PercentComplete, Mode=OneWay}"
                  ShowProgressText="True"
+                 HorizontalAlignment="Stretch"
                  Grid.Column="1" />
-    <TextBlock Text="{Binding PeerCount}" TextAlignment="End" Grid.Column="2"/>
+    <TextBlock Text="{Binding PeerCount}" TextAlignment="End" HorizontalAlignment="Right" Grid.Column="2"/>
     <TextBlock Text="{Binding Downloaded, Converter={x:Static core:Util.SizeConverter}}"
-               TextAlignment="End" Grid.Column="3" />
+               TextAlignment="End" HorizontalAlignment="Right" Grid.Column="3" />
     <TextBlock Text="{Binding Uploaded, Converter={x:Static core:Util.SizeConverter}}"
-               TextAlignment="End" Grid.Column="4" />
+               TextAlignment="End" HorizontalAlignment="Right" Grid.Column="4" />
   </Grid>
 </UserControl>


### PR DESCRIPTION
Now the bottom expander is labeled and the proportional space taken by the columns in the torrent views were tweaked.

resolves #54 

this took 2 hours